### PR TITLE
Use testclock from juju/clock.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module gopkg.in/retry.v1
 
 require (
+	github.com/juju/clock v0.0.0-20180808021310-bab88fc67299
 	github.com/juju/errors v0.0.0-20180726005433-812b06ada177 // indirect
 	github.com/juju/loggo v0.0.0-20180524022052-584905176618 // indirect
 	github.com/juju/retry v0.0.0-20160928201858-1998d01ba1c3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/juju/clock v0.0.0-20180808021310-bab88fc67299 h1:K9nBHQ3UNqg/HhZkQnGG2AE4YxDyNmGS9FFT2gGegLQ=
+github.com/juju/clock v0.0.0-20180808021310-bab88fc67299/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/errors v0.0.0-20180726005433-812b06ada177 h1:UliPGoJWlIH3IkkFqnPy/xYF/2tkTRTZhMt8/CwGUvw=
 github.com/juju/errors v0.0.0-20180726005433-812b06ada177/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/loggo v0.0.0-20180524022052-584905176618 h1:MK144iBQF9hTSwBW/9eJm034bVoG30IshVm688T2hi8=

--- a/retry_test.go
+++ b/retry_test.go
@@ -6,10 +6,9 @@ package retry_test // import "gopkg.in/retry.v1"
 import (
 	"time"
 
-	"github.com/juju/testing"
+	"github.com/juju/clock/testclock"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/utils/clock"
 	"gopkg.in/retry.v1"
 )
 
@@ -89,7 +88,7 @@ func (*retrySuite) TestAttemptWithStop(c *gc.C) {
 }
 
 func (*retrySuite) TestAttemptWithLaterStop(c *gc.C) {
-	clock := testing.NewClock(time.Now())
+	clock := testclock.NewClock(time.Now())
 	stop := make(chan struct{})
 	done := make(chan struct{})
 	progress := make(chan struct{}, 10)
@@ -119,7 +118,7 @@ func (*retrySuite) TestAttemptWithLaterStop(c *gc.C) {
 }
 
 func (*retrySuite) TestAttemptWithMockClock(c *gc.C) {
-	clock := testing.NewClock(time.Now())
+	clock := testclock.NewClock(time.Now())
 	strategy := retry.Regular{
 		Delay: 5 * time.Second,
 		Total: 30 * time.Second,
@@ -402,7 +401,7 @@ func closeTo(d0, d1 time.Duration) bool {
 }
 
 type mockClock struct {
-	clock.Clock
+	retry.Clock
 
 	now   time.Time
 	sleep func(d time.Duration)


### PR DESCRIPTION
Update the test to use the testclock from the new location, which is github.com/juju/clock.

Also remove the need to use utils/clock in the test by using the Clock definition from the retry package itself.